### PR TITLE
M1 Macでも動くように修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM --platform=linux/amd64 golang:1.15 AS entrykit
 RUN go get -v -ldflags "-s -w" github.com/progrium/entrykit/cmd
 
-FROM --platform=linux/amd64 centos:7.8.2003
+FROM --platform=linux/amd64 centos:7.9.2009
 
 #locale 追加
 RUN sed -i -e '/override_install_langs/s/$/,ja_JP.utf8/g' /etc/yum.conf \


### PR DESCRIPTION
やったこと
- マルチステージビルドでentrykitを入れる
- ベースイメージで`--platform=linux/amd64`を指定
- yumのインストールがコケるので手前でupdateを実行
- composer 2系を使おうとするので1系で固定
  - 2系だとprestissimoのインストールで要らないって言われる
  - prestissimoのインストールやめてもその後のスクリプトで怒られた記憶
- rootでcomposer installできるようにした